### PR TITLE
fix: load the delta time series rows since the last time

### DIFF
--- a/storage/clickhouse/clickhouse.go
+++ b/storage/clickhouse/clickhouse.go
@@ -301,7 +301,7 @@ func (ch *clickHouse) prepareClickHouseQuery(query *prompb.Query, metricName str
 	}
 	whereClause := strings.Join(conditions, " AND ")
 
-	clickHouseQuery = fmt.Sprintf(`SELECT fingerprint FROM %s.time_series_v2 WHERE %s`, ch.database, whereClause)
+	clickHouseQuery = fmt.Sprintf(`SELECT DISTINCT fingerprint FROM %s.time_series_v2 WHERE %s`, ch.database, whereClause)
 	return clickHouseQuery, nil
 }
 

--- a/storage/clickhouse/clickhouse.go
+++ b/storage/clickhouse/clickhouse.go
@@ -152,7 +152,7 @@ func (ch *clickHouse) runTimeSeriesReloader(ctx context.Context) {
 			}
 			ch.lastLoadedTimeStamp = time.Now().UnixMilli()
 			ch.timeSeriesRW.Unlock()
-			ch.l.Infof("Loaded %d new time series", len(timeSeries))
+			ch.l.Debugf("Loaded %d new time series", len(timeSeries))
 		} else {
 			ch.l.Error(err)
 		}

--- a/storage/clickhouse/json.go
+++ b/storage/clickhouse/json.go
@@ -66,17 +66,21 @@ func marshalLabels(labels []*prompb.Label, b []byte) []byte {
 
 // unmarshalLabels unmarshals JSON into Prometheus labels.
 // It does not preserves an order.
-func unmarshalLabels(b []byte) ([]*prompb.Label, error) {
+func unmarshalLabels(b []byte) ([]*prompb.Label, string, error) {
+	var metricName string
 	m := make(map[string]string)
 	if err := json.Unmarshal(b, &m); err != nil {
-		return nil, err
+		return nil, metricName, err
 	}
 	res := make([]*prompb.Label, 0, len(m))
 	for n, v := range m {
+		if n == "__name__" {
+			metricName = v
+		}
 		res = append(res, &prompb.Label{
 			Name:  n,
 			Value: v,
 		})
 	}
-	return res, nil
+	return res, metricName, nil
 }


### PR DESCRIPTION
Part of https://github.com/SigNoz/engineering-pod/issues/484

Updates the time series loader to load only the unknown entries since the last tick and eliminate the need to read and unmarshall. It also adds the opt in mechanism to use the native clickhouse query to get the matching fingerprints for the filter criteria. I had to use `labels` with `JSONExtractString` because an user is free to enter whatever they wish in the label key/value but the coulmn might not exist in `labels_object` JSON and it throws no column error. 