### PR TITLE
Use distributed tables and update query for `IN`

### DIFF
--- a/storage/clickhouse/clickhouse.go
+++ b/storage/clickhouse/clickhouse.go
@@ -38,9 +38,9 @@ import (
 )
 
 const (
-	subsystem         = "clickhouse"
-	TIME_SERIES_TABLE = "time_series_v2"
-	SAMPLES_TABLE     = "samples_v2"
+	subsystem                     = "clickhouse"
+	DISTRIBUTED_TIME_SERIES_TABLE = "distributed_time_series_v2"
+	DISTRIBUTED_SAMPLES_TABLE     = "distributed_samples_v2"
 )
 
 // clickHouse implements storage interface for the ClickHouse.
@@ -133,7 +133,7 @@ func (ch *clickHouse) runTimeSeriesReloader(ctx context.Context) {
 		lastLoadedTimeStamp := time.Now().Add(time.Duration(-1) * time.Minute).UnixMilli()
 
 		err := func() error {
-			query := fmt.Sprintf(queryTmpl, ch.database, TIME_SERIES_TABLE)
+			query := fmt.Sprintf(queryTmpl, ch.database, DISTRIBUTED_TIME_SERIES_TABLE)
 			ch.l.Debug("Running reloader query:", query)
 			rows, err := ch.db.Query(query, ch.lastLoadedTimeStamp)
 			if err != nil {
@@ -255,8 +255,8 @@ func (ch *clickHouse) querySamples(
 	query := fmt.Sprintf(`
 		SELECT metric_name, fingerprint, timestamp_ms, value
 			FROM %s.%s
-			WHERE metric_name = $1 AND fingerprint IN (%s) AND timestamp_ms >= $%s AND timestamp_ms <= $%s ORDER BY fingerprint, timestamp_ms;`,
-		ch.database, SAMPLES_TABLE, subQuery, strconv.Itoa(argCount+2), strconv.Itoa(argCount+3))
+			WHERE metric_name = $1 AND fingerprint GLOBAL IN (%s) AND timestamp_ms >= $%s AND timestamp_ms <= $%s ORDER BY fingerprint, timestamp_ms;`,
+		ch.database, DISTRIBUTED_SAMPLES_TABLE, subQuery, strconv.Itoa(argCount+2), strconv.Itoa(argCount+3))
 	query = strings.TrimSpace(query)
 
 	ch.l.Debugf("Running query : %s", query)
@@ -341,7 +341,7 @@ func (ch *clickHouse) prepareClickHouseQuery(query *prompb.Query, metricName str
 	}
 	whereClause := strings.Join(conditions, " AND ")
 
-	clickHouseQuery = fmt.Sprintf(`SELECT DISTINCT %s FROM %s.%s WHERE %s`, selectString, ch.database, TIME_SERIES_TABLE, whereClause)
+	clickHouseQuery = fmt.Sprintf(`SELECT DISTINCT %s FROM %s.%s WHERE %s`, selectString, ch.database, DISTRIBUTED_TIME_SERIES_TABLE, whereClause)
 
 	return clickHouseQuery, args, nil
 }


### PR DESCRIPTION
This includes the changes from this commit https://github.com/SigNoz/prometheus/commit/57c52fcaaba67584822eb6ef9265220c8fdf390d and also updates the query to use `GLOBAL IN`